### PR TITLE
Font cleanup + small text improvements

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,13 +2,6 @@ import "intl";
 import "intl/locale-data/jsonp/en";
 import "react-native-gesture-handler";
 
-import { Montserrat_600SemiBold } from "@expo-google-fonts/montserrat";
-import { Outfit_400Regular, Outfit_700Bold } from "@expo-google-fonts/outfit";
-import {
-  Poppins_400Regular,
-  Poppins_500Medium,
-  Poppins_600SemiBold,
-} from "@expo-google-fonts/poppins";
 import { NavigationContainer } from "@react-navigation/native";
 import { useFonts } from "expo-font";
 import React, { useState } from "react";
@@ -30,12 +23,6 @@ import { User } from "./src/types/User";
 
 export default function App() {
   const [fontsLoaded] = useFonts({
-    Montserrat_600SemiBold,
-    Poppins_400Regular,
-    Poppins_500Medium,
-    Poppins_600SemiBold,
-    Outfit_400Regular,
-    Outfit_700Bold,
     THICCCBOI_ExtraBold: require("./assets/fonts/THICCCBOI-ExtraBold.ttf"),
     THICCCBOI_Bold: require("./assets/fonts/THICCCBOI-Bold.ttf"),
     THICCCBOI_Medium: require("./assets/fonts/THICCCBOI-Medium.ttf"),

--- a/package.json
+++ b/package.json
@@ -14,9 +14,6 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@expo-google-fonts/montserrat": "^0.2.2",
-    "@expo-google-fonts/outfit": "^0.2.2",
-    "@expo-google-fonts/poppins": "^0.2.2",
     "@react-native-community/masked-view": "^0.1.11",
     "@react-native-masked-view/masked-view": "0.2.6",
     "@react-navigation/bottom-tabs": "^6.3.1",

--- a/src/components/Chat/ChatListItem.tsx
+++ b/src/components/Chat/ChatListItem.tsx
@@ -44,7 +44,7 @@ export const ChatListItem = (props: Props) => {
       <View style={styles.buttonContainer}>
         <Avatar user={lastMessage.sender}></Avatar>
         <View style={{ flex: 1 }}>
-          <Text style={styles.messageName}>
+          <Text style={styles.chatName}>
             {name}
 
             {totalUnReadMessages > 0 && (
@@ -69,9 +69,9 @@ export const ChatListItem = (props: Props) => {
 };
 
 const styles = StyleSheet.create({
-  messageName: {
-    fontFamily: "Poppins_500Medium",
-    fontSize: 16,
+  chatName: {
+    fontFamily: "THICCCBOI_Bold",
+    fontSize: 20,
     lineHeight: 24,
     color: "#353945",
   },
@@ -85,20 +85,20 @@ const styles = StyleSheet.create({
     paddingTop: 2,
   },
   totalUnReadMessagesText: {
-    fontFamily: "Montserrat_600SemiBold",
+    fontFamily: "THICCCBOI_ExtraBold",
     color: "#FFFFFF",
     fontSize: 8,
   },
   lastMessage: {
-    fontFamily: "Poppins_400Regular",
-    fontSize: 14,
+    fontFamily: "THICCCBOI_Regular",
+    fontSize: 16,
     lineHeight: 24,
     color: "#777E90",
   },
   messageTime: {
     fontSize: 12,
     paddingTop: 6,
-    fontFamily: "Outfit_700Bold",
+    fontFamily: "THICCCBOI_Bold",
     alignSelf: "flex-start",
     color: "#D9D7E6",
   },

--- a/src/components/Chat/ChatListItem.tsx
+++ b/src/components/Chat/ChatListItem.tsx
@@ -43,26 +43,26 @@ export const ChatListItem = (props: Props) => {
     >
       <View style={styles.buttonContainer}>
         <Avatar user={lastMessage.sender}></Avatar>
+
         <View style={{ flex: 1 }}>
-          <Text style={styles.chatName}>
-            {name}
+          <View style={{ flexDirection: "row", alignItems: "flex-start" }}>
+            <Text style={styles.chatName}>{name}</Text>
 
             {totalUnReadMessages > 0 && (
-              <>
-                {" "}
-                <View style={styles.totalUnReadMessages}>
-                  <Text style={styles.totalUnReadMessagesText}>
-                    {totalUnReadMessages}
-                  </Text>
-                </View>
-              </>
+              <View style={styles.totalUnReadMessages}>
+                <Text style={styles.totalUnReadMessagesText}>
+                  {totalUnReadMessages}
+                </Text>
+              </View>
             )}
-          </Text>
+
+            <Text style={styles.messageTime}>{elapsedTime}</Text>
+          </View>
+
           <Text style={styles.lastMessage} numberOfLines={1}>
             {lastMessage?.text}
           </Text>
         </View>
-        <Text style={styles.messageTime}>{elapsedTime}</Text>
       </View>
     </TouchableOpacity>
   );
@@ -78,16 +78,14 @@ const styles = StyleSheet.create({
   totalUnReadMessages: {
     borderRadius: 2,
     backgroundColor: "#14B69A",
-    textAlign: "center",
-    paddingBottom: 2,
-    paddingLeft: 4,
-    paddingRight: 4,
-    paddingTop: 2,
+    paddingVertical: 2,
+    paddingHorizontal: 4,
+    margin: 4,
   },
   totalUnReadMessagesText: {
     fontFamily: "THICCCBOI_ExtraBold",
     color: "#FFFFFF",
-    fontSize: 8,
+    fontSize: 10,
   },
   lastMessage: {
     fontFamily: "THICCCBOI_Regular",
@@ -99,7 +97,8 @@ const styles = StyleSheet.create({
     fontSize: 12,
     paddingTop: 6,
     fontFamily: "THICCCBOI_Bold",
-    alignSelf: "flex-start",
+    flex: 1,
+    textAlign: "right",
     color: "#D9D7E6",
   },
   button: {

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -88,7 +88,7 @@ const styles = StyleSheet.create({
     maxHeight: 230,
   },
   messageInput: {
-    fontFamily: "Outfit_400Regular",
+    fontFamily: "THICCCBOI_Medium",
     fontSize: 16,
     lineHeight: 20,
     color: "#5E5B71",

--- a/src/components/ReplyBubble.tsx
+++ b/src/components/ReplyBubble.tsx
@@ -51,7 +51,7 @@ const styles = StyleSheet.create({
 
   sender: {
     marginBottom: 2,
-    fontFamily: "Outfit_400Regular",
+    fontFamily: "THICCCBOI_ExtraBold",
     fontSize: 12,
   },
   senderColorSelf: {
@@ -62,7 +62,7 @@ const styles = StyleSheet.create({
   },
 
   text: {
-    fontFamily: "Outfit_400Regular",
+    fontFamily: "THICCCBOI_Medium",
     fontSize: 14,
     color: "#5E5B71",
     paddingLeft: 12,

--- a/src/screens/Chat/ChatList.tsx
+++ b/src/screens/Chat/ChatList.tsx
@@ -41,9 +41,9 @@ const ChatList: React.FC<Props> = ({ navigation }) => {
 
 const styles = StyleSheet.create({
   title: {
-    fontSize: 24,
+    fontSize: 34,
     fontWeight: "bold",
-    fontFamily: "Poppins_600SemiBold",
+    fontFamily: "THICCCBOI_ExtraBold",
     color: "#FFFFFF",
     paddingHorizontal: 16,
     marginTop: 4,

--- a/src/screens/Chat/NewChat.tsx
+++ b/src/screens/Chat/NewChat.tsx
@@ -112,7 +112,7 @@ const NewChat: React.FC<Props> = ({ navigation }) => {
                 />
                 <Text style={styles.snrLabel}>.snr</Text>
                 <TouchableOpacity onPress={onPressGo}>
-                  <Text>Go</Text>
+                  <Text style={{ color: "#5E5B71" }}>Go</Text>
                 </TouchableOpacity>
               </View>
             </TouchableWithoutFeedback>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1062,21 +1062,6 @@
   dependencies:
     "@types/hammerjs" "^2.0.36"
 
-"@expo-google-fonts/montserrat@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@expo-google-fonts/montserrat/-/montserrat-0.2.2.tgz#1c2522b6fcacf7a3b561db2f3fd7a90a52613db1"
-  integrity sha512-kpK++6mnyPPNVuZQ5ScU/YmvNsbDQGNgxwPgkmAKFrctAhfwg4KxotmmuNnn2ZaKLPtGYjP8/M8JIO3/tAm9ag==
-
-"@expo-google-fonts/outfit@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@expo-google-fonts/outfit/-/outfit-0.2.2.tgz#7badcc65649ce95b175038a1422a611df2dcdcda"
-  integrity sha512-0M27jjGxc5dKmw7SC9opSWY3E2LvbYf13ZD7mU1DdfmUlB6SOP9+DIyzN24RVx2WpEkEPAN4iweUoy8xu00A4Q==
-
-"@expo-google-fonts/poppins@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@expo-google-fonts/poppins/-/poppins-0.2.2.tgz#d2a343fa69400ffbaf61ae97162791a59e215678"
-  integrity sha512-x0SzC8nWTC2pInIcBDiAuMJxhoglwqCGJYMM8ylI8HKDqBxMrfRTripB3xMGo6UtzROTcL+OX1w9nEcM5FK0PQ==
-
 "@expo/config-plugins@4.0.6":
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-4.0.6.tgz#ef52f0e4d96ddd52b4cd4cc8c6efbe3d9576c72d"


### PR DESCRIPTION
# Description
- removed all fonts and left only thiccccccccccboi
- improved list item on chat list so that we can fit more message preview
- updated some font colors and sizes

<img width="407" alt="image" src="https://user-images.githubusercontent.com/1557361/168830561-ddda4db2-8814-439d-ad45-e83c8159c322.png">


<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>