### PR TITLE
[Fix] Links not being clickable when followed by separators other than space

### DIFF
--- a/src/_data/chats.tsx
+++ b/src/_data/chats.tsx
@@ -222,6 +222,13 @@ export const fakeChats: Chat[] = [
         reactions: [],
         forwardedFrom: "matheus.snr",
       },
+      {
+        id: "13",
+        text: "hey, check this: https://www.pivotaltracker.com/n/projects/2561773",
+        sender: Dylan,
+        timestamp: 1653420979002,
+        reactions: [],
+      },
     ],
   },
 ];

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -36,21 +36,14 @@ export const MessageBubble = (props: Props) => {
           </View>
         )}
         <Text style={[stylesCommon.text, stylesCustom.text]}>
-          {splitText.map(({ word, url }, index) => {
-            const spacedWord =
-              word + (index === splitText.length - 1 ? "" : " ");
+          {splitText.map(({ word, separator, url }, index) => {
             return url ? (
-              <Text
-                key={index}
-                onPress={() => {
-                  Linking.openURL(url);
-                }}
-                style={{ textDecorationLine: "underline" }}
-              >
-                {spacedWord}
-              </Text>
+              <>
+                <Link text={word} url={url} index={index} />
+                {separator}
+              </>
             ) : (
-              spacedWord
+              word + separator
             );
           })}
         </Text>
@@ -74,6 +67,20 @@ export const MessageBubble = (props: Props) => {
         </View>
       )}
     </View>
+  );
+};
+
+const Link = (props: { text: string; url: string; index: number }) => {
+  return (
+    <Text
+      key={props.index}
+      onPress={() => {
+        Linking.openURL(props.url);
+      }}
+      style={{ textDecorationLine: "underline" }}
+    >
+      {props.text}
+    </Text>
   );
 };
 

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Linking, StyleSheet, Text, View } from "react-native";
 
 import { getTime } from "../lib/getTime";
-import { normalizeUrl } from "../lib/normalizeUrl";
+import { splitMessageText } from "../lib/splitMessageText";
 
 import IconForwarded from "../icons/Forwarded";
 
@@ -17,10 +17,7 @@ type Props = {
 
 export const MessageBubble = (props: Props) => {
   const stylesCustom = props.isIncoming ? stylesIncoming : stylesOutgoing;
-  const parsedText = props.text.split(" ").map((word) => ({
-    word,
-    url: normalizeUrl(word),
-  }));
+  const splitText = splitMessageText(props.text);
 
   return (
     <View style={stylesCustom.container}>
@@ -39,9 +36,9 @@ export const MessageBubble = (props: Props) => {
           </View>
         )}
         <Text style={[stylesCommon.text, stylesCustom.text]}>
-          {parsedText.map(({ word, url }, index) => {
+          {splitText.map(({ word, url }, index) => {
             const spacedWord =
-              word + (index === parsedText.length - 1 ? "" : " ");
+              word + (index === splitText.length - 1 ? "" : " ");
             return url ? (
               <Text
                 key={index}

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -48,6 +48,7 @@ export const MessageBubble = (props: Props) => {
                 onPress={() => {
                   Linking.openURL(url);
                 }}
+                style={{ textDecorationLine: "underline" }}
               >
                 {spacedWord}
               </Text>

--- a/src/lib/splitMessageText.test.ts
+++ b/src/lib/splitMessageText.test.ts
@@ -1,0 +1,41 @@
+import { splitMessageText } from "./splitMessageText";
+
+describe("splitMessageText", () => {
+  it("turns into array of words", () => {
+    const split = splitMessageText("hi");
+    expect(split.length).toBe(1);
+    expect(split[0].word).toBe("hi");
+  });
+
+  it("splits on white space", () => {
+    const split = splitMessageText("hello, brother");
+    expect(split.length).toBe(2);
+    expect(split[0].word).toBe("hello,");
+    expect(split[1].word).toBe("brother");
+  });
+
+  it("adds url property", () => {
+    const split = splitMessageText("http://pudim.com.br/");
+    expect(split.length).toBe(1);
+    expect(split[0].word).toBe("http://pudim.com.br/");
+    expect(split[0].url).toBe("http://pudim.com.br/");
+  });
+
+  it("sets url property as null when word is not url", () => {
+    const split = splitMessageText("check this: http://pudim.com.br/");
+    expect(split.length).toBe(3);
+    expect(split[0].word).toBe("check");
+    expect(split[0].url).toBe(null);
+    expect(split[1].word).toBe("this:");
+    expect(split[1].url).toBe(null);
+    expect(split[2].word).toBe("http://pudim.com.br/");
+    expect(split[2].url).toBe("http://pudim.com.br/");
+  });
+
+  it("normalizes url", () => {
+    const split = splitMessageText("pudim.com.br");
+    expect(split.length).toBe(1);
+    expect(split[0].word).toBe("pudim.com.br");
+    expect(split[0].url).toBe("https://pudim.com.br");
+  });
+});

--- a/src/lib/splitMessageText.test.ts
+++ b/src/lib/splitMessageText.test.ts
@@ -7,34 +7,43 @@ describe("splitMessageText", () => {
     expect(split[0].word).toBe("hi");
   });
 
-  it("splits on white space", () => {
-    const split = splitMessageText("hello, brother");
+  it("splits on space", () => {
+    const split = splitMessageText("hello brother");
     expect(split.length).toBe(2);
-    expect(split[0].word).toBe("hello,");
+    expect(split[0].word).toBe("hello");
     expect(split[1].word).toBe("brother");
+  });
+
+  it("splits on separators other than space", () => {
+    const split = splitMessageText("Sugar,\nsugar");
+    expect(split.length).toBe(2);
+    expect(split[0].word).toBe("Sugar");
+    expect(split[1].word).toBe("sugar");
+  });
+
+  it("includes separators", () => {
+    const split = splitMessageText("Sugar (sweet)");
+    expect(split.length).toBe(2);
+    expect(split[0].word).toBe("Sugar");
+    expect(split[0].separator).toBe(" (");
+    expect(split[1].word).toBe("sweet");
+    expect(split[1].separator).toBe(")");
   });
 
   it("adds url property", () => {
     const split = splitMessageText("http://pudim.com.br/");
-    expect(split.length).toBe(1);
     expect(split[0].word).toBe("http://pudim.com.br/");
     expect(split[0].url).toBe("http://pudim.com.br/");
   });
 
   it("sets url property as null when word is not url", () => {
-    const split = splitMessageText("check this: http://pudim.com.br/");
-    expect(split.length).toBe(3);
-    expect(split[0].word).toBe("check");
+    const split = splitMessageText("SUGAR: http://pudim.com.br/");
+    expect(split[0].word).toBe("SUGAR:");
     expect(split[0].url).toBe(null);
-    expect(split[1].word).toBe("this:");
-    expect(split[1].url).toBe(null);
-    expect(split[2].word).toBe("http://pudim.com.br/");
-    expect(split[2].url).toBe("http://pudim.com.br/");
   });
 
   it("normalizes url", () => {
     const split = splitMessageText("pudim.com.br");
-    expect(split.length).toBe(1);
     expect(split[0].word).toBe("pudim.com.br");
     expect(split[0].url).toBe("https://pudim.com.br");
   });

--- a/src/lib/splitMessageText.ts
+++ b/src/lib/splitMessageText.ts
@@ -1,5 +1,11 @@
 import { normalizeUrl } from "./normalizeUrl";
 
 export const splitMessageText = (text: string) => {
-  return text.split(" ").map((word) => ({ word, url: normalizeUrl(word) }));
+  const regexp = /(([^  \n,\(\))]+)([ \n,\(\)]*))+?/g;
+  const matches = [...text.matchAll(regexp)];
+  return matches.map((group) => ({
+    word: group[2],
+    separator: group[3],
+    url: normalizeUrl(group[2]),
+  }));
 };

--- a/src/lib/splitMessageText.ts
+++ b/src/lib/splitMessageText.ts
@@ -1,0 +1,5 @@
+import { normalizeUrl } from "./normalizeUrl";
+
+export const splitMessageText = (text: string) => {
+  return text.split(" ").map((word) => ({ word, url: normalizeUrl(word) }));
+};


### PR DESCRIPTION
# Description
- https://www.pivotaltracker.com/story/show/182239184
- fixed links not being clickable when followed by some characters like new line or closing parenthesis
- there might still be more characters that we want to consider as link delimiters. now it's easy to just add them to the list if we need
- one case I couldn't solve yet was for `. ` after the link 😢. but that's not too bad because a lot of links still work if you add a period to them. please let me know if you have any ideas
- also added underline style
- thanks ✌🏻 

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>