### PR TITLE
Update owner to sonr-io in app.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ you can download the latest version by download the expo app for your device:
 
 and use this url
 
-https://expo.dev/%40prad.snr/sonr-beam?serviceType=classic&distribution=expo-go&releaseChannel=staging
+https://expo.dev/@sonr-io/sonr-beam?serviceType=classic&distribution=expo-go&release-channel=staging

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "Beam",
     "slug": "sonr-beam",
     "version": "1.0.0",
-    "owner": "prad.snr",
+    "owner": "sonr-io",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "splash": {


### PR DESCRIPTION
# Description

The account on Expo was linked to my personal account as opposed to the Sonr organization. I converted that account to an organization named sonr-io. This retains everyone's access to expo, however, the app.json needs to change the owner property in order to successfully link to the project. This PR is for that change.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>