### PR TITLE
Fix line height on message bubble to improve emoji display

### DIFF
--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -108,7 +108,7 @@ const stylesCommon = StyleSheet.create({
   text: {
     fontFamily: "THICCCBOI_Medium",
     fontSize: 16,
-    lineHeight: 20,
+    lineHeight: 22,
   },
   time: {
     fontFamily: "THICCCBOI_ExtraBold",


### PR DESCRIPTION
# Description
- stop cutting emoji tops on msg bubble

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>