### PR TITLE
[Fix] Normalize user names

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -12,8 +12,7 @@ import { useFonts } from "expo-font";
 
 import ChatScreen from "./src/screens/Chat";
 import LoginScreen from "./src/screens/Login";
-import { User } from "./src/types/User";
-import { Chat } from "./src/types/Chat";
+import { Chat, User } from "./src/types/Chat";
 
 const Stack = createStackNavigator();
 

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { StyleSheet, View } from "react-native";
 
-import { User } from "../../types/User";
+import { User } from "../../types/Chat";
 import IconUser from "../../icons/User";
 
 export const Avatar = (props: { user: User }) => {

--- a/src/components/Chat/ChatItem.tsx
+++ b/src/components/Chat/ChatItem.tsx
@@ -2,8 +2,7 @@ import React from "react";
 import { StyleSheet, View } from "react-native";
 import { Swipeable } from "react-native-gesture-handler";
 
-import { Message } from "../../types/Chat";
-import { User } from "../../types/User";
+import { Message, User } from "../../types/Chat";
 import { MessageBubble } from "../MessageBubble";
 import { ReplyBubble } from "../ReplyBubble";
 

--- a/src/components/Chat/ChatListItem.tsx
+++ b/src/components/Chat/ChatListItem.tsx
@@ -12,7 +12,11 @@ type Props = {
 };
 
 export const ChatListItem = (props: Props) => {
-  const { name, lastSeen, messages } = props.chat;
+  const {
+    lastSeen,
+    messages,
+    user: { name },
+  } = props.chat;
 
   const lastMessage = messages[messages.length - 1] || {
     timestamp: Date.now(),

--- a/src/components/UserList.tsx
+++ b/src/components/UserList.tsx
@@ -6,7 +6,7 @@ import {
   TouchableOpacity,
   SectionList,
 } from "react-native";
-import { User } from "../types/User";
+import { User } from "../types/Chat";
 import { Avatar } from "./Avatar/Avatar";
 
 type Props = {

--- a/src/components/UserSelector.tsx
+++ b/src/components/UserSelector.tsx
@@ -11,7 +11,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { useChatContext } from "../contexts/ChatContext";
 import IconClose from "../icons/Close";
-import { User } from "../types/User";
+import { User } from "../types/Chat";
 import { UserList } from "./UserList";
 
 interface Props {

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -4,9 +4,8 @@ import { useUserContext } from "./UserContext";
 import { useEmojiHistoryContext } from "./EmojiHistoryContext";
 import { charFromEmojiObject } from "../lib/emoji";
 
-import { Chat } from "../types/Chat";
+import { Chat, User } from "../types/Chat";
 import { Emoji } from "../types/Emoji";
-import { User } from "../types/User";
 
 type AddMessage = (params: {
   id: string;

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext } from "react";
 
-import { User } from "../types/User";
+import { User } from "../types/Chat";
 
 type UserContextType = { user: User };
 const UserContext = createContext<UserContextType>({

--- a/src/lib/matrix.ts
+++ b/src/lib/matrix.ts
@@ -11,8 +11,7 @@ import {
 import { SyncState } from "matrix-js-sdk/lib/sync";
 import { client } from "../matrixClient";
 
-import { Chat } from "../types/Chat";
-import { User } from "../types/User";
+import { Chat, User } from "../types/Chat";
 
 export const login = async (user: string, password: string) => {
   client.stopClient();

--- a/src/lib/matrix.ts
+++ b/src/lib/matrix.ts
@@ -50,7 +50,6 @@ const getChatFromRoom = async (room: Room): Promise<Chat> => {
     }));
   return {
     id: room.roomId,
-    name: interlocutor.name,
     user: {
       id: interlocutor.userId,
       name: interlocutor.name,

--- a/src/lib/matrix.ts
+++ b/src/lib/matrix.ts
@@ -12,6 +12,7 @@ import { SyncState } from "matrix-js-sdk/lib/sync";
 import { client } from "../matrixClient";
 
 import { Chat, User } from "../types/Chat";
+import nameFromMatrixId from "./nameFromMatrixId";
 
 export const login = async (user: string, password: string) => {
   client.stopClient();
@@ -52,7 +53,7 @@ const getChatFromRoom = async (room: Room): Promise<Chat> => {
     id: room.roomId,
     user: {
       id: interlocutor.userId,
-      name: interlocutor.name,
+      name: nameFromMatrixId(interlocutor.userId),
       isOnline: false,
     },
     lastSeen: 0,

--- a/src/lib/matrixHooks.ts
+++ b/src/lib/matrixHooks.ts
@@ -54,7 +54,6 @@ export const useListeners = () => {
             id,
             lastSeen: 0,
             messages: [],
-            name,
             isMember: false,
             user,
           });

--- a/src/lib/nameFromMatrixId.test.ts
+++ b/src/lib/nameFromMatrixId.test.ts
@@ -1,0 +1,11 @@
+import nameFromMatrixId from "./nameFromMatrixId";
+
+describe("nameFromMatrixId", () => {
+  it("extracts name", () => {
+    expect(nameFromMatrixId("@name:matrix.org")).toBe("name");
+  });
+
+  it("returns input if not a valid id", () => {
+    expect(nameFromMatrixId("dracarys")).toBe("dracarys");
+  });
+});

--- a/src/lib/nameFromMatrixId.ts
+++ b/src/lib/nameFromMatrixId.ts
@@ -1,0 +1,8 @@
+const matrixIdPattern = /\@(.+):.*/;
+
+export default (matrixId: string) => {
+  const result = matrixIdPattern.exec(matrixId);
+  if (!result) return matrixId;
+
+  return result[1];
+};

--- a/src/screens/Chat/ChatView.tsx
+++ b/src/screens/Chat/ChatView.tsx
@@ -22,13 +22,11 @@ import { useChatContext } from "../../contexts/ChatContext";
 import { useUserContext } from "../../contexts/UserContext";
 import IconArrowDown from "../../icons/ArrowDown";
 import IconBackArrow from "../../icons/BackArrow";
-// import IconBeam from "../../icons/Beam";
-// import IconMore from "../../icons/More";
+
 import { getFormattedDay } from "../../lib/getFormattedDay";
 import { useScrollback } from "../../lib/matrixHooks";
 import { client } from "../../matrixClient";
-import { Chat, Message, ViewableMessage } from "../../types/Chat";
-import { User } from "../../types/User";
+import { Chat, Message, User, ViewableMessage } from "../../types/Chat";
 
 const toViewable = (messages: Message[]): ViewableMessage[] => {
   const messageItems: ViewableMessage[] = messages.map((m) => ({

--- a/src/screens/Chat/ForwardMenu.tsx
+++ b/src/screens/Chat/ForwardMenu.tsx
@@ -9,7 +9,7 @@ import UserSelector from "../../components/UserSelector";
 import { useChatContext } from "../../contexts/ChatContext";
 import { client } from "../../matrixClient";
 
-import { User } from "../../types/User";
+import { User } from "../../types/Chat";
 
 type Props = StackScreenProps<Params, "ForwardMenu">;
 

--- a/src/screens/Chat/NewChat.tsx
+++ b/src/screens/Chat/NewChat.tsx
@@ -61,7 +61,6 @@ const NewChat: React.FC<Props> = ({ navigation }) => {
       id: response.room_id,
       lastSeen: 0,
       messages: [],
-      name: id,
       isMember: true,
       user: {
         id: fullId,

--- a/src/screens/Chat/NewChat.tsx
+++ b/src/screens/Chat/NewChat.tsx
@@ -10,7 +10,7 @@ import { UserList } from "../../components/UserList";
 import { useChatContext } from "../../contexts/ChatContext";
 import { useListeners } from "../../lib/matrixHooks";
 import { client } from "../../matrixClient";
-import { User } from "../../types/User";
+import { User } from "../../types/Chat";
 
 type Props = StackScreenProps<Params, "NewChat">;
 

--- a/src/screens/Chat/NewChat.tsx
+++ b/src/screens/Chat/NewChat.tsx
@@ -43,13 +43,11 @@ const NewChat: React.FC<Props> = ({ navigation }) => {
       return;
     }
 
-    try {
-      await client.getProfileInfo(fullId);
-    } catch {
+    const profile = await client.getProfileInfo(fullId).catch(() => {
       setLoading(false);
       setError(true);
-      return;
-    }
+    });
+    if (!profile) return;
 
     const response = await client.createRoom({
       invite: [fullId],

--- a/src/types/Chat.ts
+++ b/src/types/Chat.ts
@@ -1,4 +1,8 @@
-import { User } from "./User";
+export type User = {
+  id: string;
+  name: string;
+  isOnline: boolean;
+};
 
 export type Reaction = {
   emoji: string;

--- a/src/types/Chat.ts
+++ b/src/types/Chat.ts
@@ -25,10 +25,9 @@ export type ViewableMessage = Message & { last: boolean; showDate: boolean };
 
 export type Chat = {
   id: string;
-  name: string;
-  user: User;
   lastSeen: number;
   isMember: boolean;
+  user: User;
   messages: Message[];
 };
 

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,5 +1,0 @@
-export type User = {
-  id: string;
-  name: string;
-  isOnline: boolean;
-};


### PR DESCRIPTION
# Description
- https://www.pivotaltracker.com/story/show/182431539
- no longer using the name set on element.io
- now we only use the long or short versions of the matrix identifier (`@name:matrix.sonr.network`)

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>