### PR TITLE
[Fix] Reactions not being displayed to user who reacted

### DIFF
--- a/src/screens/Chat/MessageMenu.tsx
+++ b/src/screens/Chat/MessageMenu.tsx
@@ -18,7 +18,6 @@ import { EmojiPresetBar } from "../../components/Emojis/EmojiPresetBar";
 import { EmojiSelector } from "../../components/Emojis/EmojiSelector";
 import { MessageBubble } from "../../components/MessageBubble";
 import { MessageInput } from "../../components/MessageInput";
-import { useChatContext } from "../../contexts/ChatContext";
 import { useUserContext } from "../../contexts/UserContext";
 import IconForward from "../../icons/Forward";
 import IconReply from "../../icons/Reply";
@@ -34,12 +33,11 @@ const MessageMenu: React.FC<Props> = ({ navigation, route }) => {
   const { message, chatId } = route.params;
   const insets = useSafeAreaInsets();
   const { user } = useUserContext();
-  const { addReaction } = useChatContext();
   const [showEmojiSelector, setShowEmojiSelector] = useState(false);
 
-  const pushEmoji = async (emoji: Emoji) => {
-    addReaction(chatId, message.id as string, emoji);
-    await client.sendMessage(chatId, {
+  const pushEmoji = (emoji: Emoji) => {
+    navigation.goBack();
+    client.sendMessage(chatId, {
       msgtype: "m.reaction",
       body: "",
       messageId: message.id,


### PR DESCRIPTION
# Description
- because we're no longer ignoring events from the own user, it was undoing the reaction that was being added by invoking `addReaction` manually

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>