### PR TITLE
Fix reply bubble showing name from element.io profile

### DIFF
--- a/src/components/Chat/ChatItem.tsx
+++ b/src/components/Chat/ChatItem.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { StyleSheet, View } from "react-native";
 import { Swipeable } from "react-native-gesture-handler";
+import nameFromMatrixId from "../../lib/nameFromMatrixId";
 
 import { Message, User } from "../../types/Chat";
 import { MessageBubble } from "../MessageBubble";
@@ -44,7 +45,7 @@ export const ChatItem: React.FC<Props> = ({
         <View style={styles.parentMessageContainer}>
           <ReplyBubble
             text={parentText}
-            senderName={parentSender.name}
+            senderName={nameFromMatrixId(parentSender.id)}
             selfReply={selfReply}
             isIncoming={!isSender}
           />


### PR DESCRIPTION
# Description
<img width="382" alt="image" src="https://user-images.githubusercontent.com/1557361/174306518-e5f3924e-81fb-4fc5-9282-65be19b8b679.png">
- this should be the last place where we were still using matrix name instead of id

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>